### PR TITLE
Spawn `node` with the tsc binary, fixes #2

### DIFF
--- a/bin/command-helper.js
+++ b/bin/command-helper.js
@@ -51,7 +51,7 @@ var Helper = {};
 Helper.findTSCExecutable = function () {
     var command = '';
 
-    glob.sync('**/@(.bin|bin)/tsc', {dot: true}).forEach(function (path) {
+    glob.sync('**/@(.bin|bin)/tsc.cmd', {dot: true}).forEach(function (path) {
         if ((path.match(/\/bin\/tsc/) && !command) || path.match(/\/\.bin\/tsc/)) {
             command = path;
         }

--- a/bin/command-helper.js
+++ b/bin/command-helper.js
@@ -49,13 +49,13 @@ var Helper = {};
  * @returns {string}
  */
 Helper.findTSCExecutable = function () {
-    var command = '';
+    var command = 'node_modules/.bin/tsc';
 
-    glob.sync('**/@(.bin|bin)/tsc', {dot: true}).forEach(function (path) {
-        if ((path.match(/\/bin\/tsc/) && !command) || path.match(/\/\.bin\/tsc/)) {
-            command = path;
-        }
-    });
+    //glob.sync('**/@(.bin|bin)/tsc', {dot: true}).forEach(function (path) {
+    //    if ((path.match(/\/bin\/tsc/) && !command) || path.match(/\/\.bin\/tsc/)) {
+    //        command = path;
+    //    }
+    //});
 
     if (!command) {
         error('Missing Typescript compiler executable [tsc].');

--- a/bin/command-helper.js
+++ b/bin/command-helper.js
@@ -51,7 +51,7 @@ var Helper = {};
 Helper.findTSCExecutable = function () {
     var command = '';
 
-    glob.sync('**/@(.bin|bin)/tsc.cmd', {dot: true}).forEach(function (path) {
+    glob.sync('**/@(.bin|bin)/tsc', {dot: true}).forEach(function (path) {
         if ((path.match(/\/bin\/tsc/) && !command) || path.match(/\/\.bin\/tsc/)) {
             command = path;
         }

--- a/bin/tsc-glob.js
+++ b/bin/tsc-glob.js
@@ -7,7 +7,7 @@ const spawn = require('child_process').spawn,
 var options = helper.getOptions(),
     commandArgs = options.unknown.concat(helper.resolveTSFiles());
 
-var proc = spawn(helper.findTSCExecutable(), commandArgs, { stdio: 'inherit' });
+var proc = spawn('node', ['node_modules/typescript/lib/tsc.js'].concat(commandArgs), { stdio: 'inherit' });
 proc.on('exit', function (code, signal) {
     process.on('exit', function(){
         if (signal) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Typescript compiler wrapper to support 'filesGlob' tsconfig.json file option",
   "main": "index.js",
+  "bin": {
+    "tsc-glob": "bin/tsc-glob.js"
+  },
   "scripts": {
     "test": "_mocha",
     "test:coverage": "istanbul cover _mocha",


### PR DESCRIPTION
#2

This is a crude fix, and I can't say if this will still work for non-Windows, and so I urge you to try it out. I like this package as it does not involve modifying the `tsconfig.json`.